### PR TITLE
Add update dyanmo functionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.gu"
 
 name := "dynamo-db-switches"
 
-version := "0.3"
+version := "0.4"
 
 scalaVersion := "2.11.7"
 

--- a/src/main/scala/com/gu/dynamodbswitches/Switch.scala
+++ b/src/main/scala/com/gu/dynamodbswitches/Switch.scala
@@ -1,9 +1,20 @@
 package com.gu.dynamodbswitches
 
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+
 case class Switch(name: String, default: Boolean = false) {
   @volatile private var state: Boolean = default
 
   def enabled: Boolean = state
 
   def enabled_=(value: Boolean) = state = value
+
+  def toStringAttribute() = {
+    new AttributeValue().withS(this.name)
+  }
+
+  def asAttributeValue(b: Boolean) = {
+    val str = if(b) "1" else "0"
+    new AttributeValue().withN(str)
+  }
 }


### PR DESCRIPTION
- Adds the functionality for the dynamo dependancy to update a switch remotely 
- Also adds functionality to "get" the state of the switches live and surpass the scheduler
- Bumps version to 0.4 (still needs to be published)

Used in :
- https://github.com/guardian/discussion-platform/pull/277
 - https://github.com/guardian/discussion-api/pull/557