### PR TITLE
Support Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import sbtrelease.ReleaseStateTransformations._
 
 organization := "com.gu"
 name := "dynamo-db-switches"
-scalaVersion := "2.12.8"
+scalaVersion := "2.11.8"
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.10.28",
+  "com.amazonaws" % "aws-java-sdk" % "1.12.236",
   "org.clapper" %% "grizzled-slf4j" % "1.3.0",
   "org.scalacheck" %% "scalacheck" % "1.12.6" % "test"
 )

--- a/src/main/scala/com/gu/dynamodbswitches/Switches.scala
+++ b/src/main/scala/com/gu/dynamodbswitches/Switches.scala
@@ -1,7 +1,7 @@
 package com.gu.dynamodbswitches
 
 import collection.JavaConverters._
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, PutRequest, ScanRequest, WriteRequest}
 import grizzled.slf4j.Logging
 import com.amazonaws.AmazonServiceException
@@ -9,7 +9,7 @@ import com.amazonaws.AmazonServiceException
 trait Switches extends Logging {
   val all: List[Switch]
 
-  def dynamoDbClient: AmazonDynamoDBClient
+  def dynamoDbClient: AmazonDynamoDB
   val dynamoDbTableName: String = "featureSwitches"
 
   lazy private val processor = DynamoDbResultProcessor(all)


### PR DESCRIPTION
## What does this change?

Upgrades library to Scala 2.12 so that modtools can upgrade to Play 2.16.

At the same time, bumps the AWS SDK version, and switches to expect the more generic `AmazonDynamoDB` instead of a `AmazonDynamoDBClient` so that users can stop using a deprecated constructor for `AmazonDynamoDBClient`.