### PR TITLE
Updated sdk version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,11 +3,9 @@ import sbtrelease.ReleaseStateTransformations._
 organization := "com.gu"
 name := "dynamo-db-switches"
 scalaVersion := "2.12.8"
-val awsSdkVersion = "2.16.25"
 
 libraryDependencies ++= Seq(
-  "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,
-  "software.amazon.awssdk" % "dynamodb-enhanced" % awsSdkVersion,
+  "software.amazon.awssdk" % "dynamodb" % "2.16.25",
   "org.clapper" %% "grizzled-slf4j" % "1.3.0",
   "org.scalacheck" %% "scalacheck" % "1.12.6" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,16 @@ import sbtrelease.ReleaseStateTransformations._
 organization := "com.gu"
 name := "dynamo-db-switches"
 scalaVersion := "2.12.8"
+val awsSdkVersion = "2.16.25"
+
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk" % "1.10.28",
+  "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,
+  "software.amazon.awssdk" % "dynamodb-enhanced" % awsSdkVersion,
   "org.clapper" %% "grizzled-slf4j" % "1.3.0",
   "org.scalacheck" %% "scalacheck" % "1.12.6" % "test"
 )
-sources in doc in Compile := List()
+
+Compile / doc / sources := List()
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/src/main/scala/com/gu/dynamodbswitches/Switch.scala
+++ b/src/main/scala/com/gu/dynamodbswitches/Switch.scala
@@ -1,20 +1,20 @@
 package com.gu.dynamodbswitches
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 case class Switch(name: String, default: Boolean = false) {
   @volatile private var state: Boolean = default
 
   def enabled: Boolean = state
 
-  def enabled_=(value: Boolean) = state = value
+  def enabled_=(value: Boolean): Unit = state = value
 
-  def toStringAttribute() = {
-    new AttributeValue().withS(this.name)
+  def toStringAttribute(): AttributeValue = {
+    AttributeValue.builder().s(this.name).build()
   }
 
-  def asAttributeValue(b: Boolean) = {
+  def asAttributeValue(b: Boolean): AttributeValue = {
     val str = if(b) "1" else "0"
-    new AttributeValue().withN(str)
+    AttributeValue.builder().n(str).build()
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.2-SNAPSHOT"
+ThisBuild / version := "0.6.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Updates AWS SDK.
Some codebases which rely on this (namely, [discussion-api](https://github.com/guardian/discussion-api), but maybe more) and have updated to v2 of the aws java sdk, cannot use this, because the trait `Switches` expects the v1 version of Dynamo DB client.
Need a new release of this for updated clients
