### PR TITLE
Fix private constructor to use builder in new AWS sdk

### DIFF
--- a/src/test/scala/com/gu/dynamodbswitches/DynamoDbResultProcessorSpec.scala
+++ b/src/test/scala/com/gu/dynamodbswitches/DynamoDbResultProcessorSpec.scala
@@ -3,7 +3,7 @@ package com.gu.dynamodbswitches
 import org.scalacheck._
 import Prop._
 import Arbitrary.arbitrary
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 class DynamoDbResultProcessorSpec extends Properties("DynamoDbResultProcessor") {
   val switchNameGenerator: Gen[String] = Gen.oneOf((1 to 20).map(i => s"switch_$i"))
@@ -21,7 +21,7 @@ class DynamoDbResultProcessorSpec extends Properties("DynamoDbResultProcessor") 
 
   implicit val arbitraryProcessor: Arbitrary[DynamoDbResultProcessor] = Arbitrary {
     for {
-      switches <- arbitrary[List[Switch]]
+      switches <- arbitrary[List[Switch]].suchThat(_.nonEmpty)
     } yield new DynamoDbResultProcessor(switches.distinctBy(_.name))
   }
 
@@ -31,27 +31,26 @@ class DynamoDbResultProcessorSpec extends Properties("DynamoDbResultProcessor") 
         switch <- Gen.oneOf(processor.switches)
         state <- arbitrary[Boolean]
       } yield Map(
-        processor.DynamoDbKeyName -> new AttributeValue(processor.DynamoDbKeyName).withS(switch.name),
-        processor.DynamoDbValueName -> new AttributeValue(processor.DynamoDbValueName).withN(
-          (if (state) 1 else 0).toString)
+        processor.DynamoDbKeyName -> AttributeValue.builder().s(switch.name).build(),
+        processor.DynamoDbValueName -> AttributeValue.builder().n((if (state) 1 else 0).toString).build()
       )
     }
 
     implicit val arbitraryUpdateSet = Arbitrary {
       for {
         updates <- arbitrary[List[Map[String, AttributeValue]]]
-      } yield updates.distinctBy(_(processor.DynamoDbKeyName).getS)
+      } yield updates.distinctBy(_(processor.DynamoDbKeyName).s())
     }
 
     forAll { (updates: List[Map[String, AttributeValue]]) =>
       val ProcessingResults(switchUpdates, missing) = processor.process(updates)
 
       val missingSwitchKeys =
-        processor.switches.map(_.name).toSet.diff(updates.map(_(processor.DynamoDbKeyName).getS).toSet).size
+        processor.switches.map(_.name).toSet.diff(updates.map(_(processor.DynamoDbKeyName).s()).toSet).size
 
       val stateUpdates = updates count { update =>
-        processor.switches.exists(switch => switch.name == update(processor.DynamoDbKeyName).getS &&
-          switch.enabled != (update(processor.DynamoDbValueName).getN.toInt == 1))
+        processor.switches.exists(switch => switch.name == update(processor.DynamoDbKeyName).s() &&
+          switch.enabled != (update(processor.DynamoDbValueName).n().toInt == 1))
       }
 
       switchUpdates.size == stateUpdates && missing.size == missingSwitchKeys


### PR DESCRIPTION
## What does this change?

Just a bug fix. In AWS, you can no longer use
```scala
new MyType().withValue(someValue)
```
You have to use
```scala
MyType.builder().value(someValue).build()
```
which is fun, and easy to forget it seems