### PR TITLE
Migrate Teamcity CI build to GHA workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: corretto
+          cache: sbt
+
+      - name: SBT test
+        run: sbt clean compile test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
           cache: sbt
 
       - name: SBT test
-        run: sbt clean compile test
+        run: sbt +clean +compile +test


### PR DESCRIPTION
This replaces the following Teamcity build config with a new GHA workflow:
```
package Discussion_DynamoDbSwitches.buildTypes

import jetbrains.buildServer.configs.kotlin.*
import jetbrains.buildServer.configs.kotlin.buildSteps.simpleBuildTool
import jetbrains.buildServer.configs.kotlin.triggers.vcs

object Discussion_DynamoDbSwitches_DyanmoDbSwitches : BuildType({
    id("DyanmoDbSwitches")
    name = "Compile and Test"

    vcs {
        root(Discussion_HttpsGithubComGuardianDynamoDbSwitches)

        checkoutMode = CheckoutMode.ON_SERVER
        cleanCheckout = true
    }
    steps {
        simpleBuildTool {
            jvmArgs = "-Xmx512m -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=128m"
        }
    }
    triggers {
        vcs {
            branchFilter = """
                +:*
                -:refs/heads/master
            """.trimIndent()
        }
    }
})
```
