### PR TITLE
Migrate Teamcity release build to GHA workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,14 @@ name: Release
 # Only want one release to be running at a time
 concurrency: release
 
-# Build a release every time a PR is merged
+# Build a release every time a code-change PR is merged
 on:
   push:
     branches:
       - main
+    paths:
+      - '**.scala'
+      - '**.sbt'
 
 jobs:
   Release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+# Only want one release to be running at a time
+concurrency: release
+
+# Build a release every time a PR is merged
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # To allow ciReleaseTagNextVersion to push a tag to the repo
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full set of tags to be able to calculate the next version.
+          # Currently, that only seems to be possible by fetching the entire history of the repo.
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: corretto
+          cache: sbt
+
+      - name: Import GPG key
+        # Version pinned so that we know exactly what it does
+        # - don't change this without inspecting the code!
+        uses: crazy-max/ghaction-import-gpg@232931e03ba660f66ea1e4250007329245837ec5
+        with:
+          gpg_private_key: ${{ secrets.PGP_SECRET }}
+          passphrase: ${{ secrets.PGP_PASSPHRASE }}
+
+      # See https://index.scala-lang.org/shiftleftsecurity/sbt-ci-release-early
+      - name: SBT release
+        run: sbt +clean +compile +Test/compile +test ciReleaseTagNextVersion ciReleaseSonatype
+        env:
+          # Name part of user token
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          # Password part of user token
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ project/plugins/project/
 .idea
 .idea_modules
 
+/gnupg-*

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import sbtrelease.ReleaseStateTransformations._
-
 organization := "com.gu"
 name := "dynamo-db-switches"
 scalaVersion := "2.13.10"
@@ -12,20 +10,3 @@ libraryDependencies ++= Seq(
 )
 
 Compile / doc / sources := List()
-
-releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
-releaseProcess := Seq[ReleaseStep](
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  // For non cross-build projects, use releaseStepCommand("publishSigned")
-  releaseStepCommandAndRemaining("+publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.15")
+// Used by release workflow (.github/workflows/release.yml)
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "2.0.45")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "0.6.2-SNAPSHOT"


### PR DESCRIPTION
This replaces the following broken Teamcity build config with a new GHA workflow:
```
package Discussion_DynamoDbSwitches.buildTypes

import jetbrains.buildServer.configs.kotlin.*

object Discussion_DynamoDbSwitches_Release : BuildType({
    id("Release")
    name = "release"

    buildNumberPattern = "0.%build.counter%"

    params {
        password("encryption_password", "******")
    }

    vcs {
        root(Discussion_DynamoDbSwitches_HttpsGithubComGuardianDynamoDbSwitchesRefsHeadsMas_2)
    }

    steps {
        script {
            name = "decrypt secrets"
            scriptContent = "bash build.sh '%encryption_password%' '%build.number%'"
        }
        simpleBuildTool {
            commands = "clean compile test publishSigned sonatypeReleaseAll"
            jvmArgs = "-Xmx512m -XX:MaxPermSize=256m -XX:ReservedCodeCacheSize=128m"
        }
    }

    triggers {
        vcs {
            branchFilter = "+:refs/heads/master"
        }
    }
})
```

The `build.sh` script doesn't appear to exist!

After this change, we'll be building a new production release on every PR merge.
It has successfully built:
* [release 0.6.4 for Scala 2.12](https://repo1.maven.org/maven2/com/gu/dynamo-db-switches_2.12/0.6.4/)
* [release 0.6.4 for Scala 2.13](https://repo1.maven.org/maven2/com/gu/dynamo-db-switches_2.13/0.6.4/)
 