### PR TITLE
Update scala and sbt versions for scala-steward

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization := "com.gu"
 name := "dynamo-db-switches"
-scalaVersion := "2.13.10"
-crossScalaVersions := Seq(scalaVersion.value, "2.12.17")
+scalaVersion := "2.13.14"
+crossScalaVersions := Seq(scalaVersion.value, "2.12.19")
 
 // Minimum versions of transitive dependencies required to avoid vulnerabilities
 val minTransitiveVersions = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.10.1


### PR DESCRIPTION
This repository recently [caused scala-steward to fail](https://github.com/guardian/scala-steward-public-repos/actions/runs/10197804136/job/28211404564), because it doesn’t currently meet the minimum required sbt and scala versions for scala steward to work. (Those versions are outlined in [this issue](https://github.com/guardian/maintaining-scala-projects/issues/7).

This PR updates the sbt version in use to the newest versions and the two scala versions in use to the latest patch versions for those minor versions.

This should be sufficient to let scala-steward run on this repository: I have managed to successfully run `sbt +test` locally with these changes using Java 21.