### PR TITLE
Specify @guardian/identity in new CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/identity


### PR DESCRIPTION
It looks like @guardian/identity are the owners of this repo:

* @guardian/identity is the only GitHub team [specified](https://github.com/guardian/dynamo-db-switches/settings/access) for 'admin' access to this repo
* GitHub search shows that [4 repos](https://github.com/search?q=org%3Aguardian+dynamo-db-switches+language%3AScala++NOT+is%3Aarchived+NOT+repo%3Aguardian%2Fdynamo-db-switches&type=code) use this library, and these look to be Identity/Discussion related!:
  * https://github.com/guardian/identity
  * https://github.com/guardian/discussion-api-test-scala-dependabot
  * https://github.com/guardian/discussion-modtools
  * https://github.com/guardian/discussion-api

A lot of our Guardian security infrastructure (like the [Dependency Vulnerabilities by Team](https://metrics.gutools.co.uk/d/fdib3p8l85jwgd/dependency-vulnerabilities-by-team?orgId=1&var-repo_owner=identity) dashboard) decides which team is the owner of a repository by checking **which teams have admin access to it** (ignoring the CODEOWNERS file), so the CODEOWNERS file is not the ultimate source of truth for us, as far as I'm aware.

However, for developers who aren't admin's on the repo, and so don't have access to the https://github.com/guardian/dynamo-db-switches/settings/access page, they can't see which teams _are_ the admins, and so a CODEOWNERS file would be very helpful to them!

See also:

* https://github.com/guardian/dynamo-db-switches/pull/27#issuecomment-2263179244


