### PR TITLE
Replace setup-java with setup-scala step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v4
-        with:
-          java-version: 11
-          distribution: corretto
-          cache: sbt
+      - uses: guardian/setup-scala@v1
 
       - name: SBT test
         run: sbt +clean +compile +test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.25.9.1


### PR DESCRIPTION
This replaces the `setup-java` step with `setup-scala` now that SBT has to be installed as well.

Setting Java version to latest Corretto 11 release.