### PR TITLE
hopefully fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,7 @@ jobs:
           # Currently, that only seems to be possible by fetching the entire history of the repo.
           fetch-depth: 0
 
-      - uses: actions/setup-java@v4
-        with:
-          java-version: 11
-          distribution: corretto
-          cache: sbt
+      - uses: guardian/setup-scala@v1
 
       - name: Import GPG key
         # Version pinned so that we know exactly what it does


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

the release fails with `sbt: command not found`. I think this might have been missed on this previous pr: https://github.com/guardian/manage-help-content-publisher/pull/532/files
